### PR TITLE
Issue/43/parallelization

### DIFF
--- a/research/scripts/basic_inf_script.py
+++ b/research/scripts/basic_inf_script.py
@@ -15,7 +15,36 @@ def make_true():
 
     return(true_nz)
 
-def the_loop(true_nz=None):
+def set_up_prior(data):
+    """
+    Function to create prior distribution from data
+
+    Parameters
+    ----------
+    data: dict
+        catalog dictionary containing bin endpoints, log interim prior, and log interim posteriors
+
+    Returns
+    -------
+    prior: chippr.mvn object
+        prior distribution as multivariate normal
+    """
+    zs = data['bin_ends']
+    log_nz_intp = np.exp(data['log_interim_prior'])
+    log_z_posts = np.exp(data['log_interim_posteriors'])
+
+    z_difs = zs[1:]-zs[:-1]
+    z_mids = (zs[1:]+zs[:-1])/2.
+    n_bins = len(z_mids)
+
+    prior_var = np.eye(n_bins)
+    for k in range(n_bins):
+        prior_var[k] = 1. * np.exp(-0.5 * (z_mids[k] - z_mids) ** 2 / 0.05 ** 2)
+    prior_mean = log_nz_intp
+    prior = mvn(prior_mean, prior_var)
+    return prior
+
+def the_loop(given_key):
     """
     Function to create a catalog once true redshifts exist
 
@@ -24,56 +53,54 @@ def the_loop(true_nz=None):
     true_nz: chippr.gmix object, optional
         gaussian mixture probability distribution
     """
-    result_dir = os.path.join('..', 'results')
-    name_file = 'which_inf_tests.txt'
+    test_info = all_tests[given_key]
+    test_name = test_info['name']
+    true_nz = test_info['truth']
 
-    with open(name_file) as tests_to_run:
+    test_name = test_name[:-1]
+    param_file_name = test_name + '.txt'
 
-        for test_name in tests_to_run:
+    test_dir = os.path.join(result_dir, test_name)
+    simulated_posteriors = catalog(params=param_file_name, loc=test_dir)
+    saved_location = 'data'
+    saved_type = '.txt'
+    data = simulated_posteriors.read(loc=saved_location, style=saved_type)
 
-            test_name = test_name[:-1]
-            param_file_name = test_name + '.txt'
+    prior = set_up_prior(data)
 
-            test_dir = os.path.join(result_dir, test_name)
-            simulated_posteriors = catalog(params=param_file_name, loc=test_dir)
-            saved_location = 'data'
-            saved_type = '.txt'
-            data = simulated_posteriors.read(loc=saved_location, style=saved_type)
+    nz = log_z_dens(data, prior, truth=true_nz, loc=test_dir, vb=True)
 
-            zs = data['bin_ends']
-            nz_intp = np.exp(data['log_interim_prior'])
-            z_posts = np.exp(data['log_interim_posteriors'])
+    nz_stacked = nz.calculate_stacked()
+    nz_mmap = nz.calculate_mmap()
+    nz_mexp = nz.calculate_mexp()
+    nz_stats = nz.compare()
 
-            z_difs = zs[1:]-zs[:-1]
-            z_mids = (zs[1:]+zs[:-1])/2.
-            n_bins = len(z_mids)
+    nz.plot_estimators()
 
-            prior_var = np.eye(n_bins)
-            for k in range(n_bins):
-                prior_var[k] = 1. * np.exp(-0.5 * (z_mids[k] - z_mids) ** 2 / 0.05 ** 2)
-            prior_mean = nz_intp
-            prior = mvn(prior_mean, prior_var)
-
-            nz = log_z_dens(data, prior, truth=true_nz, loc=test_dir, vb=True)
-
-            nz_stacked = nz.calculate_stacked()
-            nz_mmap = nz.calculate_mmap()
-            nz_mexp = nz.calculate_mexp()
-            nz_stats = nz.compare()
-
-            nz.info['estimators'].keys()
-            nz.plot_estimators('final_plot.png')
-            
-            nz.write('nz.p')
+    nz.write('nz.p')
 
 if __name__ == "__main__":
 
     import numpy as np
     import os
+    import multiprocessing as mp
 
     import chippr
     from chippr import *
 
     true_nz = make_true()
 
-    the_loop(true_nz=true_nz)
+    result_dir = os.path.join('..', 'results')
+    name_file = 'which_inf_tests.txt'
+
+    with open(name_file) as tests_to_run:
+        all_tests = {}
+        for test_name in tests_to_run:
+            test_info = {}
+            test_info['name'] = test_name
+            test_info['truth'] = true_nz
+            all_tests[test_name] = test_info
+
+    nps = mp.cpu_count()-1
+    pool = mp.Pool(nps)
+    pool.map(the_loop, all_tests.keys())

--- a/research/scripts/basic_inf_script.py
+++ b/research/scripts/basic_inf_script.py
@@ -1,11 +1,20 @@
-def make_true():
+def make_true_nz(test_name):
     """
     Function to create true redshift distribution to be shared among several test cases
+
+    Parameters
+    ----------
+    test_name: string
+        name used to look up parameters for making true_nz
 
     Returns
     -------
     true_nz: chippr.gmix object
         gaussian mixture probability distribution
+
+    Notes
+    -----
+    test_name is currently ignored but will soon be used to load parameters for making true_nz instead of hardcoded values.
     """
     true_amps = np.array([0.20, 0.35, 0.55])
     true_means = np.array([0.5, 0.2, 0.75])
@@ -44,14 +53,14 @@ def set_up_prior(data):
     prior = mvn(prior_mean, prior_var)
     return prior
 
-def the_loop(given_key):
+def do_inference(given_key):
     """
-    Function to create a catalog once true redshifts exist
+    Function to do inference from a catalog of photo-z interim posteriors
 
     Parameters
     ----------
-    true_nz: chippr.gmix object, optional
-        gaussian mixture probability distribution
+    given_key: string
+        name of test case to be run
     """
     test_info = all_tests[given_key]
     test_name = test_info['name']
@@ -88,14 +97,13 @@ if __name__ == "__main__":
     import chippr
     from chippr import *
 
-    true_nz = make_true()
-
     result_dir = os.path.join('..', 'results')
     name_file = 'which_inf_tests.txt'
 
     with open(name_file) as tests_to_run:
         all_tests = {}
         for test_name in tests_to_run:
+            true_nz = make_true_nz(test_name)
             test_info = {}
             test_info['name'] = test_name
             test_info['truth'] = true_nz
@@ -103,4 +111,4 @@ if __name__ == "__main__":
 
     nps = mp.cpu_count()-1
     pool = mp.Pool(nps)
-    pool.map(the_loop, all_tests.keys())
+    pool.map(do_inference, all_tests.keys())

--- a/research/scripts/basic_sim_script.py
+++ b/research/scripts/basic_sim_script.py
@@ -1,4 +1,28 @@
-def make_true():
+def make_true_nz(test_name):
+    """
+    Function to create true redshift distribution to be shared among several test cases
+
+    Parameters
+    ----------
+    test_name: string
+        name used to look up parameters for making true_nz
+
+    Returns
+    -------
+    true_nz: chippr.gmix object
+        gaussian mixture probability distribution
+
+    Notes
+    -----
+    test_name is currently ignored but will soon be used to load parameters for making true_nz instead of hardcoded values.
+    """
+    true_amps = np.array([0.20, 0.35, 0.55])
+    true_means = np.array([0.5, 0.2, 0.75])
+    true_sigmas = np.array([0.4, 0.2, 0.1])
+    true_nz = chippr.gmix(true_amps, true_means, true_sigmas, limits=(0., 1.))
+    return(true_nz)
+
+def make_true_zs(true_nz):
     """
     Function to create true redshifts to be shared among several test cases
 
@@ -7,36 +31,30 @@ def make_true():
     true_zs: numpy.ndarray, float
         array of true redshift values
     """
-    true_amps = np.array([0.20, 0.35, 0.55])
-    true_means = np.array([0.5, 0.2, 0.75])
-    true_sigmas = np.array([0.4, 0.2, 0.1])
-
-    true_nz = chippr.gmix(true_amps, true_means, true_sigmas, limits=(0., 1.))
-
     N =10**4
-
     true_zs = true_nz.sample(N)
-
     return(true_zs)
 
-def make_catalog(true_zs):
+def make_catalog(given_key):
     """
     Function to create a catalog once true redshifts exist
 
     Parameters
     ----------
-    true_zs: numpy.ndarray, float
-        array of true redshift values
+    given_key: string
+        name of test case to be run
     """
-    result_dir = os.path.join('..', 'results')
-    name_file = 'which_tests.txt'
-
     with open(name_file) as tests_to_run:
 
         for test_name in tests_to_run:
+            test_info = all_tests[given_key]
+            test_name = test_info['name']
+            true_nz = test_info['true_nz']
+            true_zs = test_info['true_zs']
 
             test_name = test_name[:-1]
             param_file_name = test_name + '.txt'
+
             params = chippr.sim_utils.ingest(param_file_name)
             params = defaults.check_sim_params(params)
 
@@ -62,10 +80,25 @@ if __name__ == "__main__":
     import numpy as np
     import os
     import shutil
+    import multiprocessing as mp
 
     import chippr
     from chippr import *
 
-    true_zs = make_true()
+    result_dir = os.path.join('..', 'results')
+    name_file = 'which_sim_tests.txt'
 
-    make_catalog(true_zs)
+    with open(name_file) as tests_to_run:
+        all_tests = {}
+        for test_name in tests_to_run:
+            true_nz = make_true_nz(test_name)
+            true_zs = make_true_zs(true_nz)
+            test_info = {}
+            test_info['name'] = test_name
+            test_info['true_nz'] = true_nz
+            test_info['true_zs'] = true_zs
+            all_tests[test_name] = test_info
+
+    nps = mp.cpu_count()-1
+    pool = mp.Pool(nps)
+    pool.map(make_catalog, all_tests.keys())


### PR DESCRIPTION
There are now scripts to simulate catalogs and do inference of multiple test cases in parallel.  They save data in a reasonable way, and there is documentation.  They should be flexible enough to permit all test cases to be run.